### PR TITLE
glob is a standard library module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy==1.16.*
 matplotlib==3.*
 seaborn==0.8.1
 pandas
-glob


### PR DESCRIPTION
It shouldn't be listed in `requirements.txt`. Maybe a different package was meant?