### PR TITLE
Fix deprecation warning when importing gaussian_filter

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "from numpy import random\n",
-    "from scipy.ndimage.filters import gaussian_filter"
+    "from scipy.ndimage import gaussian_filter"
    ]
   },
   {


### PR DESCRIPTION


This commit fixes the following warning:
```
DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace,
the `scipy.ndimage.filters` namespace is deprecated.
```

Tested on Ubuntu 22 / Python 3.10 / scipy 1.8.0
and
Debian 13 / Python 3.13 / scipy 1.15.3

Once this commit is applied, it is possible to rerun all cells of the index.ipynb notebook without any warnings or errors.